### PR TITLE
add update features, implement soft&hard volunteer deletion

### DIFF
--- a/Familia.Backend/src/Familia.API/Controllers/VolunteersController.cs
+++ b/Familia.Backend/src/Familia.API/Controllers/VolunteersController.cs
@@ -1,6 +1,12 @@
 using Familia.API.Extensions;
 using Familia.Application.Volunteers.CreateVolunteer;
+using Familia.Application.Volunteers.Delete;
+using Familia.Application.Volunteers.UpdateMainInfo;
+using Familia.Application.Volunteers.UpdateRequisite;
+using Familia.Application.Volunteers.UpdateSocialMedia;
+using FluentValidation;
 using Microsoft.AspNetCore.Mvc;
+using System.Net.WebSockets;
 
 namespace Familia.API.Controllers
 {
@@ -8,18 +14,129 @@ namespace Familia.API.Controllers
     [Route("[controller]")]
     public class VolunteersController : ControllerBase
     {
-        [HttpGet]
-        public IActionResult Get()
-        {
-            return Ok();
-        }
-
         [HttpPost]
         public async Task<ActionResult> Create(
             [FromServices] CreateVolunteerHandler handler,
             [FromBody] CreateVolunteerRequest request,
             CancellationToken cancellationToken)
         {
+            var result = await handler.Handle(request, cancellationToken);
+
+            if (result.IsFailure)
+                return result.Error.ToResponse();
+
+            return Ok(result.Value);
+        }
+
+        [HttpPut("{id:guid}/main-info")]
+        public async Task<ActionResult> UpdateMainInfo(
+            [FromRoute] Guid id,
+            [FromServices] UpdateMainInfoHandler handler,
+            [FromBody] UpdateMainInfoDto dto,
+            [FromServices] IValidator<UpdateMainInfoRequest> validator,
+            CancellationToken cancellationToken)
+        {
+            var request = new UpdateMainInfoRequest(id, dto);
+
+            var validationResult = await validator.ValidateAsync(request, cancellationToken);
+            if (validationResult.IsValid == false)
+            {
+                return validationResult.ToValidationErrorResponse();
+            }
+
+            var result = await handler.Handle(request, cancellationToken);
+
+            if (result.IsFailure)
+                return result.Error.ToResponse();
+
+            return Ok(result.Value);
+        }
+
+        [HttpPut("{id:guid}/social-media")]
+        public async Task<ActionResult> UpdateSocialMedia(
+            [FromRoute] Guid id,
+            [FromServices] UpdateSocialMediaHandler handler,
+            [FromBody] UpdateSocialMediaDto dto,
+            [FromServices] IValidator<UpdateSocialMediaRequest> validator,
+            CancellationToken cancellationToken)
+        {
+            var request = new UpdateSocialMediaRequest(id, dto);
+
+            var validationResult = await validator.ValidateAsync(request, cancellationToken);
+            if (validationResult.IsValid == false)
+            {
+                return validationResult.ToValidationErrorResponse();
+            }
+
+            var result = await handler.Handle(request, cancellationToken);
+
+            if (result.IsFailure)
+                return result.Error.ToResponse();
+
+            return Ok(result.Value);
+        }
+
+        [HttpPut("{id:guid}/help-requisite")]
+        public async Task<ActionResult> UpdateHelpRequisite(
+            [FromRoute] Guid id,
+            [FromServices] UpdateHelpRequisiteHandler handler,
+            [FromBody] UpdateHelpRequisiteDto dto,
+            [FromServices] IValidator<UpdateHelpRequisiteRequest> validator)
+        {
+            var request = new UpdateHelpRequisiteRequest(id, dto);
+
+            var validationResult = await validator.ValidateAsync(request);
+            if (validationResult.IsValid == false)
+            {
+                return validationResult.ToValidationErrorResponse();
+            }
+
+            var result = await handler.Handle(request);
+
+            if (result.IsFailure)
+                return result.Error.ToResponse();
+
+            return Ok(result.Value);
+        }
+
+        [HttpDelete("{id:guid}/hard")]
+        public async Task<ActionResult> DeleteHard(
+            [FromRoute] Guid id,
+            [FromServices] DeleteHardVolunteerHandler handler,
+            [FromServices] IValidator<DeleteVolunteerRequest> validator,
+            CancellationToken cancellationToken)
+        {
+            var request = new DeleteVolunteerRequest(id);
+
+            var validationResult = await validator.ValidateAsync(request, cancellationToken);
+            if (validationResult.IsValid == false)
+            {
+                return validationResult.ToValidationErrorResponse();
+            }
+
+            var result = await handler.Handle(request, cancellationToken);
+
+            if (result.IsFailure)
+                return result.Error.ToResponse();
+
+            return Ok(result.Value);
+        }
+
+        [HttpDelete("{id:guid}/soft")]
+        public async Task<ActionResult> DeleteSoft(
+            [FromRoute] Guid id,
+            [FromServices] DeleteSoftVolunteerHandler handler,
+            [FromServices] IValidator<DeleteVolunteerRequest> validator,
+            CancellationToken cancellationToken)
+        {
+            var request = new DeleteVolunteerRequest(id);
+
+            var validationResult = await validator.ValidateAsync(request, cancellationToken);
+            if (validationResult.IsValid == false)
+            {
+                return validationResult.ToValidationErrorResponse();
+            }
+
             var result = await handler.Handle(request, cancellationToken);
 
             if (result.IsFailure)

--- a/Familia.Backend/src/Familia.API/Extensions/ResponseExtensions.cs
+++ b/Familia.Backend/src/Familia.API/Extensions/ResponseExtensions.cs
@@ -27,5 +27,25 @@ namespace Familia.API.Extensions
                 StatusCode = statusCode
             };
         }
+
+        public static ActionResult ToValidationErrorResponse(this ValidationResult result)
+        {
+            if (result.IsValid)
+                throw new InvalidOperationException("Result can't be succed");
+            
+            var validationErrors = result.Errors;
+
+            var responseErrors = from validationError in validationErrors
+                                 let errorMessage = validationError.ErrorMessage
+                                 let error = Error.Deserialize(errorMessage)
+                                 select new ResponseError(error.Code, error.Message, validationError.PropertyName);
+
+            var envelope = Envelope.Error(responseErrors);
+
+            return new ObjectResult(envelope)
+            {
+                StatusCode = StatusCodes.Status400BadRequest
+            };
+        }
     }
 }

--- a/Familia.Backend/src/Familia.Application/DTOs/HelpRequisitesDto.cs
+++ b/Familia.Backend/src/Familia.Application/DTOs/HelpRequisitesDto.cs
@@ -1,0 +1,4 @@
+﻿namespace Familia.Application.DTOs
+{
+    public record HelpRequisitesDto(string PaymentMethod, string Details);
+}

--- a/Familia.Backend/src/Familia.Application/DTOs/HelpRequisitiesDTO.cs
+++ b/Familia.Backend/src/Familia.Application/DTOs/HelpRequisitiesDTO.cs
@@ -1,4 +1,0 @@
-﻿namespace Familia.Application.DTOs
-{
-    public record HelpRequisitiesDto(string PaymentMethod, string Details);
-}

--- a/Familia.Backend/src/Familia.Application/Inject.cs
+++ b/Familia.Backend/src/Familia.Application/Inject.cs
@@ -1,4 +1,8 @@
 ﻿using Familia.Application.Volunteers.CreateVolunteer;
+using Familia.Application.Volunteers.Delete;
+using Familia.Application.Volunteers.UpdateMainInfo;
+using Familia.Application.Volunteers.UpdateRequisite;
+using Familia.Application.Volunteers.UpdateSocialMedia;
 using FluentValidation;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -9,6 +13,11 @@ namespace Familia.Application
         public static IServiceCollection AddApplication(this IServiceCollection services)
         {
             services.AddScoped<CreateVolunteerHandler>();
+            services.AddScoped<UpdateMainInfoHandler>();
+            services.AddScoped<UpdateSocialMediaHandler>();
+            services.AddScoped<UpdateHelpRequisiteHandler>();
+            services.AddScoped<DeleteHardVolunteerHandler>();
+            services.AddScoped<DeleteSoftVolunteerHandler>();
 
             services.AddValidatorsFromAssembly(typeof(Inject).Assembly);
 

--- a/Familia.Backend/src/Familia.Application/Volunteers/CreateVolunteer/CreateVolunteerHandler.cs
+++ b/Familia.Backend/src/Familia.Application/Volunteers/CreateVolunteer/CreateVolunteerHandler.cs
@@ -28,7 +28,7 @@ namespace Familia.Application.Volunteers.CreateVolunteer
 
             var number = ContactPhone.Create(request.Number).Value;
 
-            var existingNumberVolunteer = await _volunteersRepository.GetByNumber(number);
+            var existingNumberVolunteer = await _volunteersRepository.GetByNumber(number, cancellationToken);
             if (existingNumberVolunteer.IsSuccess)
                 return Errors.General.AlreadyExist();
 
@@ -55,7 +55,7 @@ namespace Familia.Application.Volunteers.CreateVolunteer
             await _volunteersRepository.Add(volunteerResult.Value, cancellationToken);
 
             _logger.LogInformation(
-                "Created volunteer {fullname} with id {volunteerId}", fullName, volunteerId);
+                "Created volunteer {fullname} with id {volunteerId}", fullName, volunteerId.Value);
 
             return (Guid)volunteerResult.Value.Id;
         }

--- a/Familia.Backend/src/Familia.Application/Volunteers/CreateVolunteer/CreateVolunteerRequest.cs
+++ b/Familia.Backend/src/Familia.Application/Volunteers/CreateVolunteer/CreateVolunteerRequest.cs
@@ -9,5 +9,5 @@ namespace Familia.Application.Volunteers.CreateVolunteer
         string Email,
         string Number,
         IEnumerable<SocialMediaDto> SocialMedias,
-        HelpRequisitiesDto HelpRequisities);
+        HelpRequisitesDto HelpRequisities);
 }

--- a/Familia.Backend/src/Familia.Application/Volunteers/Delete/DeleteHardVolunteerHandler.cs
+++ b/Familia.Backend/src/Familia.Application/Volunteers/Delete/DeleteHardVolunteerHandler.cs
@@ -1,0 +1,35 @@
+﻿using CSharpFunctionalExtensions;
+using Familia.Domain.Shared;
+using Microsoft.Extensions.Logging;
+
+namespace Familia.Application.Volunteers.Delete
+{
+    public class DeleteHardVolunteerHandler
+    {
+        private readonly IVolunteersRepository _volunteersRepository;
+        private readonly ILogger<DeleteHardVolunteerHandler> _logger;
+
+        public DeleteHardVolunteerHandler(
+            IVolunteersRepository volunteersRepository,
+            ILogger<DeleteHardVolunteerHandler> logger)
+        {
+            _volunteersRepository = volunteersRepository;
+            _logger = logger;
+        }
+
+        public async Task<Result<Guid, Error>> Handle(
+            DeleteVolunteerRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            var volunteerResult = await _volunteersRepository.GetById(request.VolunteerId);
+            if (volunteerResult.IsFailure)
+                return volunteerResult.Error;
+
+            var result = await _volunteersRepository.Delete(volunteerResult.Value, cancellationToken);
+
+            _logger.LogInformation("Volunteer hard deleted with id {volunteerId}", request.VolunteerId);
+
+            return result;
+        }
+    }
+}

--- a/Familia.Backend/src/Familia.Application/Volunteers/Delete/DeleteSoftVolunteerHandler.cs
+++ b/Familia.Backend/src/Familia.Application/Volunteers/Delete/DeleteSoftVolunteerHandler.cs
@@ -1,0 +1,37 @@
+﻿using CSharpFunctionalExtensions;
+using Familia.Domain.Shared;
+using Microsoft.Extensions.Logging;
+
+namespace Familia.Application.Volunteers.Delete
+{
+    public class DeleteSoftVolunteerHandler
+    {
+        private readonly IVolunteersRepository _volunteersRepository;
+        private readonly ILogger<DeleteHardVolunteerHandler> _logger;
+
+        public DeleteSoftVolunteerHandler(
+            IVolunteersRepository volunteersRepository,
+            ILogger<DeleteHardVolunteerHandler> logger)
+        {
+            _volunteersRepository = volunteersRepository;
+            _logger = logger;
+        }
+
+        public async Task<Result<Guid, Error>> Handle(
+            DeleteVolunteerRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            var volunteerResult = await _volunteersRepository.GetById(request.VolunteerId);
+            if (volunteerResult.IsFailure)
+                return volunteerResult.Error;
+
+            volunteerResult.Value.Delete();
+
+            var result = await _volunteersRepository.Save(volunteerResult.Value, cancellationToken);
+
+            _logger.LogInformation("Volunteer soft deleted with id {volunteerId}", request.VolunteerId);
+
+            return result;
+        }
+    }
+}

--- a/Familia.Backend/src/Familia.Application/Volunteers/Delete/DeleteVolunteerRequest.cs
+++ b/Familia.Backend/src/Familia.Application/Volunteers/Delete/DeleteVolunteerRequest.cs
@@ -1,0 +1,4 @@
+﻿namespace Familia.Application.Volunteers.Delete
+{
+    public record DeleteVolunteerRequest(Guid VolunteerId);
+}

--- a/Familia.Backend/src/Familia.Application/Volunteers/Delete/DeleteVolunteerRequestValidator.cs
+++ b/Familia.Backend/src/Familia.Application/Volunteers/Delete/DeleteVolunteerRequestValidator.cs
@@ -1,0 +1,15 @@
+﻿using Familia.Application.Validation;
+using Familia.Domain.Shared;
+using FluentValidation;
+
+namespace Familia.Application.Volunteers.Delete
+{
+    public class DeleteVolunteerRequestValidator: AbstractValidator<DeleteVolunteerRequest>
+    {
+        public DeleteVolunteerRequestValidator()
+        {
+            RuleFor(d => d.VolunteerId).NotEmpty()
+                .WithError(Errors.General.ValueIsRequired()); ;
+        }
+    }
+}

--- a/Familia.Backend/src/Familia.Application/Volunteers/IVolunteersRepository.cs
+++ b/Familia.Backend/src/Familia.Application/Volunteers/IVolunteersRepository.cs
@@ -9,7 +9,9 @@ namespace Familia.Application.Volunteers
     public interface IVolunteersRepository
     {
         Task<Guid> Add(Volunteer volunteer, CancellationToken cancellationToken = default);
-        Task<Result<Volunteer, Error>> GetById(VolunteerId volunteerId);
-        Task<Result<Volunteer, Error>> GetByNumber(ContactPhone number);
+        Task<Guid> Save(Volunteer volunteer, CancellationToken cancellationToken = default);
+        Task<Guid> Delete(Volunteer volunteer, CancellationToken cancellationToken = default);
+        Task<Result<Volunteer, Error>> GetById(VolunteerId volunteerId, CancellationToken cancellationToken = default);
+        Task<Result<Volunteer, Error>> GetByNumber(ContactPhone number, CancellationToken cancellationToken = default);
     }
 }

--- a/Familia.Backend/src/Familia.Application/Volunteers/UpdateMainInfo/UpdateMainInfoHandler.cs
+++ b/Familia.Backend/src/Familia.Application/Volunteers/UpdateMainInfo/UpdateMainInfoHandler.cs
@@ -1,0 +1,51 @@
+﻿using CSharpFunctionalExtensions;
+using Familia.Domain.Aggregates.VolunteerAggregate.ValueObjects;
+using Familia.Domain.Shared;
+using Microsoft.Extensions.Logging;
+
+namespace Familia.Application.Volunteers.UpdateMainInfo
+{
+    public class UpdateMainInfoHandler
+    {
+        private readonly IVolunteersRepository _volunteersRepository;
+        private readonly ILogger<UpdateMainInfoHandler> _logger;
+
+        public UpdateMainInfoHandler(
+            IVolunteersRepository volunteersRepository,
+            ILogger<UpdateMainInfoHandler> logger)
+        {
+            _volunteersRepository = volunteersRepository;
+            _logger = logger;
+        }
+
+        public async Task<Result<Guid, Error>> Handle(
+            UpdateMainInfoRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            var volunteerResult = await _volunteersRepository.GetById(request.VolunteerId, cancellationToken);
+            if (volunteerResult.IsFailure)
+                return volunteerResult.Error;
+
+            var fullName = FullName.Create(
+                request.Dto.FullName.FirstName,
+                request.Dto.FullName.LastName,
+                request.Dto.FullName.Patronymic).Value;
+
+            var number = ContactPhone.Create(request.Dto.Number).Value;
+
+            volunteerResult.Value.UpdateMainInfo(
+                fullName,
+                request.Dto.Email,
+                request.Dto.Description,
+                request.Dto.YearsOfExperience,
+                number);
+
+            var result = await _volunteersRepository.Save(volunteerResult.Value, cancellationToken);
+
+            _logger.LogInformation(
+                "Updated volunteer's main info with id {volunteerId}", request.VolunteerId);
+
+            return result;
+        }
+    }
+}

--- a/Familia.Backend/src/Familia.Application/Volunteers/UpdateMainInfo/UpdateMainInfoRequest.cs
+++ b/Familia.Backend/src/Familia.Application/Volunteers/UpdateMainInfo/UpdateMainInfoRequest.cs
@@ -1,0 +1,15 @@
+﻿using Familia.Application.DTOs;
+
+namespace Familia.Application.Volunteers.UpdateMainInfo
+{
+    public record UpdateMainInfoRequest(
+        Guid VolunteerId,
+        UpdateMainInfoDto Dto);
+
+    public record UpdateMainInfoDto(
+        FullNameDto FullName,
+        string Email,
+        string Description,
+        int YearsOfExperience,
+        string Number);
+}

--- a/Familia.Backend/src/Familia.Application/Volunteers/UpdateMainInfo/UpdateMainInfoRequestValidator.cs
+++ b/Familia.Backend/src/Familia.Application/Volunteers/UpdateMainInfo/UpdateMainInfoRequestValidator.cs
@@ -1,0 +1,31 @@
+﻿using Familia.Application.Validation;
+using Familia.Domain.Aggregates.VolunteerAggregate.ValueObjects;
+using Familia.Domain.Shared;
+using FluentValidation;
+
+namespace Familia.Application.Volunteers.UpdateMainInfo
+{
+    public class UpdateMainInfoRequestValidator : AbstractValidator<UpdateMainInfoRequest>
+    {
+        public UpdateMainInfoRequestValidator()
+        {
+            RuleFor(v => v.VolunteerId).NotEmpty()
+                .WithError(Errors.General.ValueIsRequired());
+        }
+    }
+    public class UpdateMainInfoDtoValidator : AbstractValidator<UpdateMainInfoDto>
+    {
+        public UpdateMainInfoDtoValidator()
+        {
+            RuleFor(c => c.FullName)
+                .MustBeValueObject(fn => FullName.Create(
+                    fn.FirstName, fn.LastName, fn.Patronymic));
+
+            RuleFor(c => c.Number)
+                .MustBeValueObject(ContactPhone.Create);
+
+            RuleFor(c => c.YearsOfExperience).GreaterThanOrEqualTo(0)
+                .WithError(Errors.General.ValueIsInvalid("Years of experience"));
+        }
+    }
+}

--- a/Familia.Backend/src/Familia.Application/Volunteers/UpdateRequisite/UpdateHelpRequisiteHandler.cs
+++ b/Familia.Backend/src/Familia.Application/Volunteers/UpdateRequisite/UpdateHelpRequisiteHandler.cs
@@ -1,0 +1,43 @@
+﻿using CSharpFunctionalExtensions;
+using Familia.Domain.Aggregates.VolunteerAggregate.AggregateRoot;
+using Familia.Domain.Aggregates.VolunteerAggregate.ValueObjects;
+using Familia.Domain.Shared;
+using Microsoft.Extensions.Logging;
+
+namespace Familia.Application.Volunteers.UpdateRequisite
+{
+    public class UpdateHelpRequisiteHandler
+    {
+        private readonly IVolunteersRepository _volunteersRepository;
+        private readonly ILogger<UpdateHelpRequisiteHandler> _logger;
+
+        public UpdateHelpRequisiteHandler(
+            IVolunteersRepository volunteersRepository,
+            ILogger<UpdateHelpRequisiteHandler> logger)
+        {
+            _volunteersRepository = volunteersRepository;
+            _logger = logger;
+        }
+
+        public async Task<Result<Guid, Error>> Handle(
+            UpdateHelpRequisiteRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            var volunteerResult = await _volunteersRepository.GetById(request.VolunteerId, cancellationToken);
+            if (volunteerResult.IsFailure)
+                return volunteerResult.Error;
+
+            var helpRequisite = HelpRequisites.Create(
+                request.Dto.HelpRequisites.PaymentMethod,
+                request.Dto.HelpRequisites.Details).Value;
+
+            volunteerResult.Value.UpdateHelpRequisite(helpRequisite);
+
+            var result = await _volunteersRepository.Save(volunteerResult.Value, cancellationToken);
+
+            _logger.LogInformation("Help requisite updated for volunteer with Id {volunteerId}", request.VolunteerId);
+
+            return result;
+        }
+    }
+}

--- a/Familia.Backend/src/Familia.Application/Volunteers/UpdateRequisite/UpdateHelpRequisiteRequest.cs
+++ b/Familia.Backend/src/Familia.Application/Volunteers/UpdateRequisite/UpdateHelpRequisiteRequest.cs
@@ -1,0 +1,11 @@
+﻿using Familia.Application.DTOs;
+using Familia.Domain.Aggregates.VolunteerAggregate.ValueObjects;
+
+namespace Familia.Application.Volunteers.UpdateRequisite
+{
+    public record UpdateHelpRequisiteRequest(
+        Guid VolunteerId,
+        UpdateHelpRequisiteDto Dto);
+
+    public record UpdateHelpRequisiteDto(HelpRequisitesDto HelpRequisites);
+}

--- a/Familia.Backend/src/Familia.Application/Volunteers/UpdateRequisite/UpdateHelpRequisiteRequestValidator.cs
+++ b/Familia.Backend/src/Familia.Application/Volunteers/UpdateRequisite/UpdateHelpRequisiteRequestValidator.cs
@@ -1,0 +1,24 @@
+﻿using Familia.Application.Validation;
+using Familia.Domain.Aggregates.VolunteerAggregate.ValueObjects;
+using Familia.Domain.Shared;
+using FluentValidation;
+
+namespace Familia.Application.Volunteers.UpdateRequisite
+{
+    public class UpdateHelpRequisiteRequestValidator : AbstractValidator<UpdateHelpRequisiteRequest>
+    {
+        public UpdateHelpRequisiteRequestValidator()
+        {
+            RuleFor(h => h.VolunteerId).NotEmpty()
+                .WithError(Errors.General.ValueIsRequired());
+        }
+    }
+    public class UpdateHelpRequisiteDtoValidator : AbstractValidator<UpdateHelpRequisiteDto>
+    {
+        public UpdateHelpRequisiteDtoValidator()
+        {
+            RuleFor(d => d.HelpRequisites)
+                .MustBeValueObject(x => HelpRequisites.Create(x.PaymentMethod, x.Details));
+        }
+    }
+}

--- a/Familia.Backend/src/Familia.Application/Volunteers/UpdateSocialMedia/UpdateSocialMediaHandler.cs
+++ b/Familia.Backend/src/Familia.Application/Volunteers/UpdateSocialMedia/UpdateSocialMediaHandler.cs
@@ -1,0 +1,41 @@
+﻿using CSharpFunctionalExtensions;
+using Familia.Domain.Aggregates.VolunteerAggregate.ValueObjects;
+using Familia.Domain.Shared;
+using Microsoft.Extensions.Logging;
+
+namespace Familia.Application.Volunteers.UpdateSocialMedia
+{
+    public class UpdateSocialMediaHandler
+    {
+        private readonly IVolunteersRepository _volunteersRepository;
+        private readonly ILogger<UpdateSocialMediaHandler> _logger;
+
+        public UpdateSocialMediaHandler(
+            IVolunteersRepository volunteersRepository,
+            ILogger<UpdateSocialMediaHandler> logger)
+        {
+            _volunteersRepository = volunteersRepository;
+            _logger = logger;
+        }
+
+        public async Task<Result<Guid, Error>> Handle(
+            UpdateSocialMediaRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            var volunteerResult = await _volunteersRepository.GetById(request.VolunteerId, cancellationToken);
+            if (volunteerResult.IsFailure)
+                return volunteerResult.Error;
+
+            var socialMedia = request.Dto.SocialMedia.Select(
+                s => SocialMedia.Create(s.Name, s.Link).Value);
+
+            volunteerResult.Value.UpdateSocialMedia(socialMedia);
+
+            var result = await _volunteersRepository.Save(volunteerResult.Value, cancellationToken);
+
+            _logger.LogInformation("Social media updated for volunteer with Id {volunteerId}", request.VolunteerId);
+
+            return result;
+        }
+    }
+}

--- a/Familia.Backend/src/Familia.Application/Volunteers/UpdateSocialMedia/UpdateSocialMediaRequest.cs
+++ b/Familia.Backend/src/Familia.Application/Volunteers/UpdateSocialMedia/UpdateSocialMediaRequest.cs
@@ -1,0 +1,10 @@
+﻿using Familia.Application.DTOs;
+
+namespace Familia.Application.Volunteers.UpdateSocialMedia
+{
+    public record UpdateSocialMediaRequest(
+        Guid VolunteerId,
+        UpdateSocialMediaDto Dto);
+
+    public record UpdateSocialMediaDto(IEnumerable<SocialMediaDto> SocialMedia);
+}

--- a/Familia.Backend/src/Familia.Application/Volunteers/UpdateSocialMedia/UpdateSocialMediaRequestValidator.cs
+++ b/Familia.Backend/src/Familia.Application/Volunteers/UpdateSocialMedia/UpdateSocialMediaRequestValidator.cs
@@ -1,0 +1,24 @@
+﻿using Familia.Application.Validation;
+using Familia.Domain.Aggregates.VolunteerAggregate.ValueObjects;
+using Familia.Domain.Shared;
+using FluentValidation;
+
+namespace Familia.Application.Volunteers.UpdateSocialMedia
+{
+    public class UpdateSocialMediaRequestValidator : AbstractValidator<UpdateSocialMediaRequest>
+    {
+        public UpdateSocialMediaRequestValidator()
+        {
+            RuleFor(v => v.VolunteerId).NotEmpty()
+                .WithError(Errors.General.ValueIsRequired());
+        }
+    }
+    public class UpdateSocialMediaDtoValidator : AbstractValidator<UpdateSocialMediaDto>
+    {
+        public UpdateSocialMediaDtoValidator()
+        {
+            RuleForEach(s => s.SocialMedia)
+                .MustBeValueObject(s => SocialMedia.Create(s.Name, s.Link));
+        }
+    }
+}

--- a/Familia.Backend/src/Familia.Domain/Aggregates/VolunteerAggregate/AggregateRoot/Volunteer.cs
+++ b/Familia.Backend/src/Familia.Domain/Aggregates/VolunteerAggregate/AggregateRoot/Volunteer.cs
@@ -7,8 +7,9 @@ using Familia.Domain.Shared.Extenstions;
 
 namespace Familia.Domain.Aggregates.VolunteerAggregate.AggregateRoot
 {
-    public sealed class Volunteer: IdEntity<VolunteerId>
+    public sealed class Volunteer: IdEntity<VolunteerId>, ISoftDeletable
     {
+        private bool _isDeleted = false;
         private readonly List<Pet> _pets = [];
         private readonly List<SocialMedia> _socialMedias = [];
         //ef core
@@ -31,7 +32,7 @@ namespace Familia.Domain.Aggregates.VolunteerAggregate.AggregateRoot
             YearsOfExperience = yearsOfExperience;
             ContactPhone = contactPhone;
             HelpRequisites = helpRequisites;
-            _socialMedias = socialMedias;
+            _socialMedias = new List<SocialMedia>(socialMedias);
         }
         public FullName FullName { get; private set; } = default!;
         public string Email { get; private set; } = default!;
@@ -68,5 +69,45 @@ namespace Familia.Domain.Aggregates.VolunteerAggregate.AggregateRoot
         private int FoundHomeAnimalsNumber() => _pets.Count(p => p.HelpStatus == HelpStatus.FoundHome);
         private int LookingForHomeAnimalsNumber() => _pets.Count(p => p.HelpStatus == HelpStatus.LookingForHome);
         private int NeedHelpAnimalsNumber() => _pets.Count(p => p.HelpStatus == HelpStatus.NeedsHelp);
+
+        public void UpdateMainInfo
+            (FullName fullName,
+            string email,
+            string description,
+            int yearsOfExperience,
+            ContactPhone contactPhone)
+        {
+            FullName = fullName;
+            Email = email;
+            Description = description;
+            YearsOfExperience = yearsOfExperience;
+            ContactPhone = contactPhone;
+        }
+
+        public void UpdateSocialMedia
+            (IEnumerable<SocialMedia> socialMedia)
+        {
+            _socialMedias.Clear();
+            _socialMedias.AddRange(socialMedia);
+        }
+
+        public void UpdateHelpRequisite
+            (HelpRequisites helpRequisites)
+        {
+            HelpRequisites = helpRequisites;
+        }
+
+        public void Delete()
+        {
+            if (_isDeleted) return;
+
+            _isDeleted = true;
+        }
+        public void Restore()
+        {
+            if (!_isDeleted) return;
+
+            _isDeleted = false;
+        }
     }
 }

--- a/Familia.Backend/src/Familia.Domain/Aggregates/VolunteerAggregate/Entities/Pet.cs
+++ b/Familia.Backend/src/Familia.Domain/Aggregates/VolunteerAggregate/Entities/Pet.cs
@@ -9,8 +9,10 @@ using Familia.Domain.Shared.ValueObjects;
 
 namespace Familia.Domain.Aggregates.VolunteerAggregate.Entities
 {
-    public sealed class Pet : IdEntity<PetId>
+    public sealed class Pet : IdEntity<PetId>, ISoftDeletable
     {
+        private bool _isDeleted = false;
+
         //ef core navigation
         public Volunteer Volunteer { get; private set; } = null!;
 
@@ -98,6 +100,16 @@ namespace Familia.Domain.Aggregates.VolunteerAggregate.Entities
                 birthday, isVaccinated, helpStatus, creationDate);
 
             return pet;
+        }
+
+        public void Delete()
+        {
+            _isDeleted = true;
+        }
+
+        public void Restore()
+        {
+            _isDeleted = false;
         }
     }
 }

--- a/Familia.Backend/src/Familia.Domain/Shared/EntityIds/VolunteerId.cs
+++ b/Familia.Backend/src/Familia.Domain/Shared/EntityIds/VolunteerId.cs
@@ -12,6 +12,8 @@
         public static VolunteerId Empty() => new(Guid.Empty);
         public static VolunteerId Create(Guid id) => new(id);
 
+        public static implicit operator VolunteerId(Guid id) => new(id);
+
         public static implicit operator Guid(VolunteerId volunteerId)
         {
             ArgumentNullException.ThrowIfNull(volunteerId);

--- a/Familia.Backend/src/Familia.Domain/Shared/ISoftDeletable.cs
+++ b/Familia.Backend/src/Familia.Domain/Shared/ISoftDeletable.cs
@@ -1,0 +1,8 @@
+﻿namespace Familia.Domain.Shared
+{
+    public interface ISoftDeletable
+    {
+        void Delete();
+        void Restore();
+    }
+}

--- a/Familia.Backend/src/Familia.Infrastructure/ApplicationDbContext.cs
+++ b/Familia.Backend/src/Familia.Infrastructure/ApplicationDbContext.cs
@@ -1,5 +1,6 @@
 ﻿using Familia.Domain.Aggregates.SpeciesAggregate.AggregateRoot;
 using Familia.Domain.Aggregates.VolunteerAggregate.AggregateRoot;
+using Familia.Infrastructure.Interceptors;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -16,6 +17,9 @@ namespace Familia.Infrastructure
         {
             optionsBuilder.UseNpgsql(configuration.GetConnectionString(DATABASE));
             optionsBuilder.UseLoggerFactory(CreateLoggerFactory());
+            optionsBuilder.EnableSensitiveDataLogging();
+
+            //optionsBuilder.AddInterceptors(new SoftDeleteInterceptor());
         }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
@@ -23,7 +27,7 @@ namespace Familia.Infrastructure
             modelBuilder.ApplyConfigurationsFromAssembly(typeof(ApplicationDbContext).Assembly);
         }
 
-        private ILoggerFactory CreateLoggerFactory() => 
+        private ILoggerFactory CreateLoggerFactory() =>
             LoggerFactory.Create(builder => { builder.AddConsole(); });
     }
 }

--- a/Familia.Backend/src/Familia.Infrastructure/Configurations/PetConfiguration.cs
+++ b/Familia.Backend/src/Familia.Infrastructure/Configurations/PetConfiguration.cs
@@ -135,7 +135,10 @@ namespace Familia.Infrastructure.Configurations
                 .SetDefaultDateTimeKind(DateTimeKind.Utc)
                 .HasColumnName("creation_date")
                 .IsRequired();
-                
+
+            builder.Property<bool>("_isDeleted")
+                .UsePropertyAccessMode(PropertyAccessMode.Field)
+                .HasColumnName("is_deleted");
         }
     }
 }

--- a/Familia.Backend/src/Familia.Infrastructure/Configurations/VolunteerConfiguration.cs
+++ b/Familia.Backend/src/Familia.Infrastructure/Configurations/VolunteerConfiguration.cs
@@ -82,7 +82,12 @@ namespace Familia.Infrastructure.Configurations
             builder.HasMany(v => v.Pets)
                 .WithOne(p => p.Volunteer)
                 .HasForeignKey("volunteer_id")
-                .OnDelete(DeleteBehavior.NoAction);
+                .OnDelete(DeleteBehavior.Cascade);
+
+            builder.Property<bool>("_isDeleted")
+                .UsePropertyAccessMode(PropertyAccessMode.Field)
+                .HasColumnName("is_deleted")
+                .HasDefaultValue(false); ;
         }
     }
 }

--- a/Familia.Backend/src/Familia.Infrastructure/Inject.cs
+++ b/Familia.Backend/src/Familia.Infrastructure/Inject.cs
@@ -1,4 +1,5 @@
 ﻿using Familia.Application.Volunteers;
+using Familia.Infrastructure.Interceptors;
 using Familia.Infrastructure.Repositories;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -9,6 +10,7 @@ namespace Familia.Infrastructure
         public static IServiceCollection AddInfrastructure(this IServiceCollection services)
         {
             services.AddScoped<ApplicationDbContext>();
+            services.AddSingleton<SoftDeleteInterceptor>();
             services.AddScoped<IVolunteersRepository, VolunteersRepository>();
 
             return services;

--- a/Familia.Backend/src/Familia.Infrastructure/Interceptors/SoftDeleteInterceptor.cs
+++ b/Familia.Backend/src/Familia.Infrastructure/Interceptors/SoftDeleteInterceptor.cs
@@ -1,0 +1,32 @@
+﻿using Familia.Domain.Shared;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace Familia.Infrastructure.Interceptors
+{
+    public class SoftDeleteInterceptor : SaveChangesInterceptor
+    {
+        public override async ValueTask<InterceptionResult<int>> SavingChangesAsync(
+            DbContextEventData eventData,
+            InterceptionResult<int> result,
+            CancellationToken cancellationToken = default)
+        {
+            if (eventData.Context is null)
+            {
+                return await base.SavingChangesAsync(eventData, result, cancellationToken);
+            }
+
+            var entries = eventData.Context.ChangeTracker
+                .Entries<ISoftDeletable>()
+                .Where(e => e.State == EntityState.Deleted);
+
+            foreach (var entry in entries)
+            {
+                entry.State = EntityState.Modified;
+                entry.Entity.Delete();
+            }
+
+            return await base.SavingChangesAsync(eventData, result, cancellationToken);
+        }
+    }
+}

--- a/Familia.Backend/src/Familia.Infrastructure/Migrations/20250723025739_SoftDelete.Designer.cs
+++ b/Familia.Backend/src/Familia.Infrastructure/Migrations/20250723025739_SoftDelete.Designer.cs
@@ -13,15 +13,15 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Familia.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    [Migration("20250705040839_Initial")]
-    partial class Initial
+    [Migration("20250723025739_SoftDelete")]
+    partial class SoftDelete
     {
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "9.0.6")
+                .HasAnnotation("ProductVersion", "9.0.7")
                 .HasAnnotation("Relational:MaxIdentifierLength", 63);
 
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
@@ -92,6 +92,12 @@ namespace Familia.Infrastructure.Migrations
                         .HasMaxLength(2000)
                         .HasColumnType("integer")
                         .HasColumnName("years_of_experience");
+
+                    b.Property<bool>("_isDeleted")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("boolean")
+                        .HasDefaultValue(false)
+                        .HasColumnName("is_deleted");
 
                     b.ComplexProperty<Dictionary<string, object>>("ContactPhone", "Familia.Domain.Aggregates.VolunteerAggregate.AggregateRoot.Volunteer.ContactPhone#ContactPhone", b1 =>
                         {
@@ -194,6 +200,10 @@ namespace Familia.Infrastructure.Migrations
                         .HasMaxLength(100)
                         .HasColumnType("character varying(100)")
                         .HasColumnName("name");
+
+                    b.Property<bool>("_isDeleted")
+                        .HasColumnType("boolean")
+                        .HasColumnName("is_deleted");
 
                     b.Property<Guid?>("volunteer_id")
                         .HasColumnType("uuid");
@@ -302,7 +312,7 @@ namespace Familia.Infrastructure.Migrations
                     b.HasOne("Familia.Domain.Aggregates.VolunteerAggregate.AggregateRoot.Volunteer", "Volunteer")
                         .WithMany("Pets")
                         .HasForeignKey("volunteer_id")
-                        .OnDelete(DeleteBehavior.NoAction);
+                        .OnDelete(DeleteBehavior.Cascade);
 
                     b.OwnsOne("Familia.Domain.Aggregates.SpeciesAggregate.SpeciesBreed", "SpeciesBreed", b1 =>
                         {

--- a/Familia.Backend/src/Familia.Infrastructure/Migrations/20250723025739_SoftDelete.cs
+++ b/Familia.Backend/src/Familia.Infrastructure/Migrations/20250723025739_SoftDelete.cs
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 namespace Familia.Infrastructure.Migrations
 {
     /// <inheritdoc />
-    public partial class Initial : Migration
+    public partial class SoftDelete : Migration
     {
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
@@ -32,6 +32,7 @@ namespace Familia.Infrastructure.Migrations
                     description = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: false),
                     years_of_experience = table.Column<int>(type: "integer", maxLength: 2000, nullable: false),
                     social_medias = table.Column<string>(type: "text", nullable: false),
+                    is_deleted = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
                     contact_phone = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
                     first_name = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
                     lastname_name = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
@@ -78,6 +79,7 @@ namespace Familia.Infrastructure.Migrations
                     birthday = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
                     is_vaccinated = table.Column<bool>(type: "boolean", nullable: false),
                     creation_date = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    is_deleted = table.Column<bool>(type: "boolean", nullable: false),
                     city = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
                     country = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
                     house = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
@@ -95,7 +97,8 @@ namespace Familia.Infrastructure.Migrations
                         name: "FK_pets_volunteers_volunteer_id",
                         column: x => x.volunteer_id,
                         principalTable: "volunteers",
-                        principalColumn: "id");
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
                 });
 
             migrationBuilder.CreateIndex(

--- a/Familia.Backend/src/Familia.Infrastructure/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/Familia.Backend/src/Familia.Infrastructure/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -18,7 +18,7 @@ namespace Familia.Infrastructure.Migrations
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "9.0.6")
+                .HasAnnotation("ProductVersion", "9.0.7")
                 .HasAnnotation("Relational:MaxIdentifierLength", 63);
 
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
@@ -89,6 +89,12 @@ namespace Familia.Infrastructure.Migrations
                         .HasMaxLength(2000)
                         .HasColumnType("integer")
                         .HasColumnName("years_of_experience");
+
+                    b.Property<bool>("_isDeleted")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("boolean")
+                        .HasDefaultValue(false)
+                        .HasColumnName("is_deleted");
 
                     b.ComplexProperty<Dictionary<string, object>>("ContactPhone", "Familia.Domain.Aggregates.VolunteerAggregate.AggregateRoot.Volunteer.ContactPhone#ContactPhone", b1 =>
                         {
@@ -191,6 +197,10 @@ namespace Familia.Infrastructure.Migrations
                         .HasMaxLength(100)
                         .HasColumnType("character varying(100)")
                         .HasColumnName("name");
+
+                    b.Property<bool>("_isDeleted")
+                        .HasColumnType("boolean")
+                        .HasColumnName("is_deleted");
 
                     b.Property<Guid?>("volunteer_id")
                         .HasColumnType("uuid");
@@ -299,7 +309,7 @@ namespace Familia.Infrastructure.Migrations
                     b.HasOne("Familia.Domain.Aggregates.VolunteerAggregate.AggregateRoot.Volunteer", "Volunteer")
                         .WithMany("Pets")
                         .HasForeignKey("volunteer_id")
-                        .OnDelete(DeleteBehavior.NoAction);
+                        .OnDelete(DeleteBehavior.Cascade);
 
                     b.OwnsOne("Familia.Domain.Aggregates.SpeciesAggregate.SpeciesBreed", "SpeciesBreed", b1 =>
                         {

--- a/Familia.Backend/src/Familia.Infrastructure/Repositories/VolunteersRepository.cs
+++ b/Familia.Backend/src/Familia.Infrastructure/Repositories/VolunteersRepository.cs
@@ -16,7 +16,8 @@ namespace Familia.Infrastructure.Repositories
             _dbContext = dbContext;
         }
 
-        public async Task<Guid> Add(Volunteer volunteer, CancellationToken cancellationToken = default)
+        public async Task<Guid> Add(
+            Volunteer volunteer, CancellationToken cancellationToken = default)
         {
             await _dbContext.Volunteers.AddAsync(volunteer, cancellationToken);
 
@@ -25,11 +26,21 @@ namespace Familia.Infrastructure.Repositories
             return volunteer.Id;
         }
 
-        public async Task<Result<Volunteer, Error>> GetById(VolunteerId volunteerId)
+        public async Task<Guid> Save(
+            Volunteer volunteer, CancellationToken cancellationToken = default)
+        {
+            _dbContext.Volunteers.Attach(volunteer);
+            await _dbContext.SaveChangesAsync(cancellationToken);
+
+            return volunteer.Id;
+        }
+
+        public async Task<Result<Volunteer, Error>> GetById(
+            VolunteerId volunteerId, CancellationToken cancellationToken = default)
         {
             var volunteer = await _dbContext.Volunteers
                 .Include(v => v.Pets)
-                .FirstOrDefaultAsync(v => v.Id == volunteerId);
+                .FirstOrDefaultAsync(v => v.Id == volunteerId, cancellationToken);
 
             if (volunteer is null)
                 return Errors.General.NotFound(volunteerId);
@@ -37,16 +48,27 @@ namespace Familia.Infrastructure.Repositories
             return volunteer;
         }
 
-        public async Task<Result<Volunteer, Error>> GetByNumber(ContactPhone number)
+        public async Task<Result<Volunteer, Error>> GetByNumber(
+            ContactPhone number, CancellationToken cancellationToken = default)
         {
             var volunteer = await _dbContext.Volunteers
                 .Include(v => v.Pets)
-                .FirstOrDefaultAsync(n => n.ContactPhone == number);
+                .FirstOrDefaultAsync(n => n.ContactPhone == number, cancellationToken);
 
             if (volunteer is null)
                 return Errors.General.NotFound();
 
             return volunteer;
+        }
+
+        public async Task<Guid> Delete(
+            Volunteer volunteer, CancellationToken cancellationToken = default)
+        {
+            _dbContext.Volunteers.Remove(volunteer);
+
+            await _dbContext.SaveChangesAsync(cancellationToken);
+
+            return volunteer.Id;
         }
     }
 }


### PR DESCRIPTION
ID-B-10
Мы получаем Id через route и чтобы в теле его не было в реквестах для обновления реквизитах и соц. сетей были сделаны dto, чтобы получать данные без айдишника в теле для обновления(как было показано в занятии).  
Соц. сети у меня спроектированы списком у волонтера, а реквизиты как просто одиночный VO, если в дальнейшем нужно будет, то переделаю чтобы были как список.

ID-B-11
Сделал два метода в контроллере для soft и hard удаления: DeleteSoft(), DeleteHard().
Они работают через два разных хендлера, но лежат в одной фиче Delete, так как подумал, что делать отдельную для Soft и Hard перебор.
В коде остался интерсептор, но он не используется, чтобы реализация была как просится в задании.

